### PR TITLE
Refactors

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -46,6 +46,19 @@
     renderMonth(month)
   }
 
+  function renderDaysOfWeek() {
+    // days are hardcoded UTC timestamps to a week that begins on sunday and ends on saturday
+    const sundayThroughSaturdayUTCUnixTimes = [1583038800000, 1583125200000, 1583211600000, 1583298000000, 1583384400000, 1583470800000, 1583557200000]
+    const dateFormatter = new Intl.DateTimeFormat(navigator.language, { weekday: 'narrow' })
+    const daysOfWeekHTML = sundayThroughSaturdayUTCUnixTimes
+      .map(timestamp => {
+        const date = new Date(timestamp)
+        return `<div class="day-${date.getDay()}">${dateFormatter.format(date)}</div>`
+      })
+      .join('\n')
+    document.querySelector('.day-of-week').innerHTML = daysOfWeekHTML
+  }
+
   function addEventTogglers(month) {
     function reRenderCalendar({ target: { dataset: { direction } } }) {
       if (direction === 'backward') {
@@ -64,6 +77,7 @@
   function renderHTML() {
     const month = getFirstOfMonth()
     renderCalendar(month)
+    renderDaysOfWeek()
     addEventTogglers(month)
   }
 

--- a/calendar.js
+++ b/calendar.js
@@ -17,9 +17,11 @@
   function generateDaysHtml(month) {
     const days = getDaysInMonth(month)
     const dateFormatter = new Intl.DateTimeFormat(navigator.language)
-    return days.map(day => {
+    return days.map((day, i) => {
+        const firstOfMonthClass = i === 0 ? `first-of-month-day-${day.getDay()}` : ''
+        const className = `day-${day.getDay()} ${firstOfMonthClass}`.trim()
         return `
-          <button class="day-${day.getDay()}">
+          <button class="${className}">
             <time datetime="${dateFormatter.format(day)}">${day.getDate()}</time>
           </button>
         `
@@ -31,8 +33,6 @@
     const daysHtml = generateDaysHtml(month)
     const dateGrid = document.querySelector('.date-grid')
     dateGrid.innerHTML = daysHtml
-    const firstDay = document.querySelector('.date-grid button:first-child')
-    firstDay.style['grid-column'] = (month.getDay() + 1)
   }
 
   function renderMonth(month) {

--- a/index.html
+++ b/index.html
@@ -11,15 +11,7 @@
       <div class="calendar">
         <div class="month"></div>
         <div class="calendar-days">
-          <div class="day-of-week">
-            <div class="day-0">S</div>
-            <div class="day-1">M</div>
-            <div class="day-2">T</div>
-            <div class="day-3">W</div>
-            <div class="day-4">T</div>
-            <div class="day-5">F</div>
-            <div class="day-6">S</div>
-          </div>
+          <div class="day-of-week"></div>
           <div class="date-grid"></div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -93,3 +93,25 @@ main {
 .day-6 {
   color: var(--red);
 }
+/* class offsets so first of months are in the correct column */
+.first-of-month-day-0 {
+  grid-column: 1;
+}
+.first-of-month-day-1 {
+  grid-column: 2;
+}
+.first-of-month-day-2 {
+  grid-column: 3;
+}
+.first-of-month-day-3 {
+  grid-column: 4;
+}
+.first-of-month-day-4 {
+  grid-column: 5;
+}
+.first-of-month-day-5 {
+  grid-column: 6;
+}
+.first-of-month-day-6 {
+  grid-column: 7;
+}


### PR DESCRIPTION
Changes:
- Start using a class instead of a selector to offset first of months
- Use [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/DateTimeFormat) for all date displays, making this render correctly for any user anywhere in the world with whatever language is the default language in their browser